### PR TITLE
Small check that the stages argument of passed to the Engine constructor is a list

### DIFF
--- a/build_magic/core.py
+++ b/build_magic/core.py
@@ -121,7 +121,7 @@ class Engine:
         self._stages = stages or []
 
         if not isinstance(stages, list):
-            raise TypeError("stages must be a list")
+            raise TypeError("Stages must be a list.")
 
         # Sort stages by sequence.
         if len(stages) > 1:

--- a/build_magic/core.py
+++ b/build_magic/core.py
@@ -120,7 +120,8 @@ class Engine:
         self._verbose = verbose
         self._stages = stages or []
 
-        # TODO: Check to make sure stages is a list.
+        if not isinstance(stages, list):
+            raise TypeError("stages must be a list")
 
         # Sort stages by sequence.
         if len(stages) > 1:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -287,7 +287,7 @@ def test_cli_stop_on_fail(cli):
     if sys.platform == 'linux':
         assert 'cp: missing file operand' in res.output
     else:
-        assert 'usage: cp' in res.output
+        assert 'usage: cp' in res.output or 'cp: missing file operand' in res.output
     assert 'OUTPUT  : hello' not in res.output
     assert res.exit_code == ExitCode.FAILED
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -258,6 +258,11 @@ def test_engine_constructor():
     assert engine._stages[2].sequence == 2
     assert not engine._continue_on_fail
 
+def test_engine_stage_list_type_fail():
+    """Verify the stages argument must be a list."""
+    params = "dummy"
+    with pytest.raises(TypeError):
+        engine = Engine(params)
 
 def test_config_parser():
     """Verify the config parser works correctly."""


### PR DESCRIPTION
Small check that the stages argument of passed to the Engine constructor is a list. Also changed expected output for the test_cli_stop_on_fail test, since it ran the same error on my windows PC as expected on linux. 
