### PR TITLE
Add a config file template

### DIFF
--- a/build_magic/cli.py
+++ b/build_magic/cli.py
@@ -75,6 +75,7 @@ Visit https://cmmorrow.github.io/build-magic/user_guide/cli_usage/ for a detaile
 @click.option('--runner', '-r', help='The command runner to use.', type=RUNNERS)
 @click.option('--name', help='The stage name to use.', type=str)
 @click.option('--target', '-t', help='Run a particular stage by name.', type=str, multiple=True)
+@click.option('--template', help='Generates a config file template in the current directory.', is_flag=True)
 @click.option('--wd', help='The working directory to run commands from.', default='.', type=WORKINGDIR)
 @click.option('--continue/--stop', 'continue_', help='Continue to run after failure if True.', default=False)
 @click.option('--parameter', '-p', help='Key/value used for runner specific settings.', multiple=True, type=(str, str))
@@ -96,6 +97,7 @@ def build_magic(
         runner,
         name,
         target,
+        template,
         wd,
         plain,
         quiet,
@@ -112,6 +114,21 @@ def build_magic(
     if version:
         click.echo(ver)
         sys.exit(0)
+
+    if template:
+        try:
+            core.generate_config_template()
+            sys.exit(0)
+        except FileExistsError:
+            click.secho('Cannot generate the config template because it already exists!', fg='red', err=True)
+            sys.exit(reference.ExitCode.INPUT_ERROR)
+        except PermissionError:
+            click.secho(
+                "Cannot generate the config template because build-magic doesn't have permission.",
+                fg='red',
+                err=True,
+            )
+            sys.exit(reference.ExitCode.INPUT_ERROR)
 
     # Get the output type.
     if plain:

--- a/build_magic/core.py
+++ b/build_magic/core.py
@@ -2,7 +2,6 @@
 
 
 from pathlib import Path
-from pkg_resources import resource_filename
 import types
 
 import json
@@ -47,6 +46,24 @@ def iterate_sequence():
         seq += 1
 
 
+def generate_config_template():
+    """Reads the static config file template and writes the contents to a template in the current directory.
+
+    :rtype: Path
+    :return: The newly created config file.
+    """
+    filename = 'build-magic_template.yaml'
+    current = Path().cwd().resolve()
+    file = current / filename
+    if file.exists():
+        raise FileExistsError
+
+    template = Path(__file__).parent / 'static' / filename
+    content = template.read_text()
+    file.write_text(content)
+    return file
+
+
 def config_parser(config):
     """Parse the parameters from a build-magic config file.
 
@@ -55,7 +72,7 @@ def config_parser(config):
     :return: A list of stage parameters.
     """
     # Read the config schema.
-    schema = Path(resource_filename('build_magic', 'core.py')).parent / 'static' / 'config_schema.json'
+    schema = Path(__file__).parent / 'static' / 'config_schema.json'
     with open(schema, 'r') as file:
         schema = json.load(file)
 

--- a/build_magic/static/build-magic_template.yaml
+++ b/build_magic/static/build-magic_template.yaml
@@ -1,0 +1,8 @@
+build-magic:
+  - stage:
+      name: example
+      runner: local
+      environment: 'none'
+      action: default
+      commands:
+        - build: echo 'Hello World!'

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     },
     package_data={
         'build_magic': [
-            'static/config_schema.json',
+            'static/*',
         ],
     },
     install_requires=[

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,6 +131,9 @@ Options:
                                   The command runner to use.
   --name TEXT                     The stage name to use.
   -t, --target TEXT               Run a particular stage by name.
+  --template                      Generates a config file template in the
+                                  current directory.
+
   --wd DIRECTORY                  The working directory to run commands from.
   --continue / --stop             Continue to run after failure if True.
   -p, --parameter <TEXT TEXT>...  Key/value used for runner specific settings.
@@ -145,6 +148,7 @@ Options:
   --help                          Show this message and exit.
 """
     res = cli.invoke(build_magic, ['--help'])
+    print(res.output)
     assert res.exit_code == ExitCode.PASSED
     assert res.output == ref
 
@@ -346,6 +350,35 @@ def test_cli_parameters_invalid_parameter_value(cli):
     res = cli.invoke(build_magic, ['-p', 'keytype', 'dummy', 'echo hello'])
     assert res.exit_code == ExitCode.INPUT_ERROR
     assert "Validation failed: Value dummy is not one of " in res.output
+
+
+def test_cli_config_template(cli):
+    """Verify the --template option works correctly."""
+    filename = 'build-magic_template.yaml'
+    current = Path().cwd().resolve()
+    res = cli.invoke(build_magic, ['--template'])
+    assert current.joinpath(filename).exists()
+    os.remove(filename)
+    assert res.exit_code == ExitCode.PASSED
+
+
+def test_cli_template_exists(cli):
+    """Test the case where a template config file cannot be generated because one already exists."""
+    filename = 'build-magic_template.yaml'
+    current = Path.cwd().resolve()
+    Path.touch(current.joinpath(filename))
+    res = cli.invoke(build_magic, ['--template'])
+    os.remove(filename)
+    assert res.exit_code == ExitCode.INPUT_ERROR
+    assert res.output == 'Cannot generate the config template because it already exists!\n'
+
+
+def test_cli_template_permission_error(cli, mocker):
+    """Test the case where a template config file cannot be generated because the user does not have permission."""
+    mocker.patch('build_magic.core.generate_config_template', side_effect=PermissionError)
+    res = cli.invoke(build_magic, ['--template'])
+    assert res.exit_code == ExitCode.INPUT_ERROR
+    assert res.output == "Cannot generate the config template because build-magic doesn't have permission.\n"
 
 
 def test_cli_config(cli):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,10 +1,12 @@
 """This module hosts unit tests for the core classes."""
+import os
+import pathlib
 
 import pytest
 
 from build_magic.actions import Default
 from build_magic.core import (
-    config_parser, Engine, iterate_sequence, Stage, StageFactory
+    config_parser, Engine, generate_config_template, iterate_sequence, Stage, StageFactory
 )
 from build_magic.exc import ExecutionError, SetupError, TeardownError, NoJobs, ValidationError
 from build_magic.macro import Macro
@@ -263,6 +265,19 @@ def test_engine_stage_list_type_fail():
     params = "dummy"
     with pytest.raises(TypeError):
         engine = Engine(params)
+
+
+def test_generate_config_template():
+    """Verify the generate_config_template() function works correctly."""
+    filename = 'build-magic_template.yaml'
+    template = pathlib.Path(__file__).parent.parent / 'build_magic' / 'static' / filename
+    ref = template.read_text()
+
+    config = generate_config_template()
+    content = config.read_text()
+    os.unlink(config)
+    assert content == ref
+
 
 def test_config_parser():
     """Verify the config parser works correctly."""


### PR DESCRIPTION
Added the build-magic_template.yaml config file template.
Added the generate_config_template() function to core.
Added the --template option to the CLI.
Added new unit tests.

Closes #30 