### PR TITLE
long command display bug

### DIFF
--- a/build_magic/output.py
+++ b/build_magic/output.py
@@ -9,8 +9,6 @@ from colorama import Cursor, Fore, init, Style
 from build_magic import __version__ as version
 from build_magic.reference import OutputMethod
 
-from yaspin import yaspin
-
 
 class Output:
     """Interface for defining output methods."""
@@ -294,16 +292,18 @@ class Tty(Output):
         :return: None
         """
         width = self.get_width()
+        command = command.strip()
         status = Fore.YELLOW + Style.BRIGHT + 'RUNNING' + Style.RESET_ALL
         seq_length = len(str(total))
         seq = f'( {sequence:>{seq_length}}/{total:>{seq_length}} )'
         spacing = width - 23 - len(command) - len(seq)
-        if len(command) + 12 + len(seq) > width - 11:
-            command = command[:width - 24 - len(seq)] + '....'
         if not command:
             message = f'{directive.upper()} {"." * spacing}'
+        elif len(command) + 12 + len(seq) > width - 11:
+            command = command[:width - 27 - len(seq)] + ' ....'
+            message = f'{seq} {directive.upper():<8}: {command} {status:<8}'
         else:
-            message = f'{seq} {directive.upper():<8}: {command} {"." * spacing} {status}'
+            message = f'{seq} {directive.upper():<8}: {command} {"." * spacing} {status:<8}'
         self._display(message)
 
     def macro_status(self, directive='', command='', status_code=0, sequence=1, total=1):
@@ -349,7 +349,8 @@ class Tty(Output):
         message = 'OUTPUT: {}'.format(msg)
         self._display(message)
 
-    def process_spinner(self, spinner, process_active=False):
+    @staticmethod
+    def process_spinner(spinner, process_active=False):
         """Indicates whether a process is underway.
 
         :param yaspin  spinner: Yaspin spinner object.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -22,13 +22,13 @@ The easiest way to install build-magic for Linux is by installing from a package
 
 <!-- [build-magic-0.3.0_amd64.deb](https://github.com/cmmorrow/build-magic/releases/download/v0.3.0/build_magic-0.3.0_amd64.deb) -->
 
-Compatible versions are Debian 10 (buster)+, Ubuntu 18.04 (bionic)+, or Mint Linux 19 (Tara)+.
+Minimum compatible versions are Debian 10 (buster), Ubuntu 20.04 (focal fossa), or Mint Linux 19 (Tara).
 
 #### Fedora/CentOS/Red Hat
 
-<!-- [build-magic](https://github.com/cmmorrow/build-magic/releases/download/v0.2.0/build_magic-0.2.0-py2.py3-none-any.whl) -->
+[build-magic-0.3.0rc1-0.el7.x86_64.rpm](https://github.com/cmmorrow/build-magic/releases/download/v0.3.0rc1/build-magic-0.3.0rc1-0.el7.x86_64.rpm)
 
-Compatible versions are CentOS 7 or newer.
+Minimum compatible versions are CentOS/RHEL 7.9 and Fedora 33.
 
 ### Install via pipx
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -303,6 +303,22 @@ def test_tty_macro_start(capsys):
     captured = capsys.readouterr()
     assert captured.out == 'EXECUTE ..................................................\n'
 
+    output.log(OutputMethod.MACRO_START, 'execute', f'echo {"-" * 46}')
+    captured = capsys.readouterr()
+    assert captured.out == '( 1/1 ) EXECUTE : echo ----------------------------------------- .... RUNNING\n'
+
+    output.log(OutputMethod.MACRO_START, 'execute', f'echo {"-" * 45}')
+    captured = capsys.readouterr()
+    assert captured.out == '( 1/1 ) EXECUTE : echo ---------------------------------------------  RUNNING\n'
+
+    output.log(OutputMethod.MACRO_START, 'execute', f'echo {"-" * 44}')
+    captured = capsys.readouterr()
+    assert captured.out == '( 1/1 ) EXECUTE : echo -------------------------------------------- . RUNNING\n'
+
+    output.log(OutputMethod.MACRO_START, 'execute', 'echo |\n')
+    captured = capsys.readouterr()
+    assert captured.out == '( 1/1 ) EXECUTE : echo | ............................................ RUNNING\n'
+
 
 def test_tty_macro_status(capsys):
     """Verify the macro_status() method works correctly."""


### PR DESCRIPTION
* Strip whitespace and newline characters from TTY displayed commands.
* Fixed a TTY display bug that occurred when a command was longer than the allocated space in the terminal.
* Updated unit tests.

Closes #46 