### PR TITLE
hide_prompt_text_in_command

### DIFF
--- a/build_magic/cli.py
+++ b/build_magic/cli.py
@@ -221,7 +221,7 @@ def build_magic(
             variable = list(variable)
             for var in prompt:
                 value = click.prompt(f'{var}', hide_input=True)
-                variable.append((var, value))
+                variable.append((var, reference.PromptSequence.START + value + reference.PromptSequence.END))
         for cfg in config:
             stages = get_stages_from_config(cfg, dict(variable))
             stage_names = [stg.get('name') for stg in stages if stg.get('name')]

--- a/build_magic/macro.py
+++ b/build_magic/macro.py
@@ -1,6 +1,9 @@
 """Module for defining Macro classes."""
 
+import re
 import shlex
+
+from build_magic.reference import PromptSequence
 
 
 class MacroFactory:
@@ -71,12 +74,40 @@ class Macro:
 
     @property
     def command(self):
-        """Provides the command to execute.
+        """Provides the command to execute for display purposes.
+
+        Any command that contains a prompt sequence will be converted to hidden characters to mask the prompted string.
 
         :rtype: str
         :return: The Macro command.
         """
-        return self._command
+        if PromptSequence.START in self._command:
+            return self._hide_prompted_command()
+        else:
+            return self._command
+
+    def _hide_prompted_command(self):
+        """Find the prompt start and end tags and replace the whole sequence with the hidden sequence.
+
+        :return: The command with prompted sequences hidden.
+        """
+        cmd = self._command
+        # Find prompt sequences and replace them with the hidden character sequence.
+        pattern = re.compile(str(re.escape(PromptSequence.START)) + r'.*?' + str(re.escape(PromptSequence.END)))
+        prompted = re.findall(pattern, cmd)
+        for seq in prompted:
+            cmd = cmd.replace(seq, PromptSequence.HIDDEN)
+        return cmd
+
+    def _strip_prompt_from_command(self):
+        """Remove the prompt start and end tags from the command.
+
+        :return: The command without the prompt tags.
+        """
+        cmd = self._command
+        if PromptSequence.START in cmd:
+            cmd = cmd.replace(PromptSequence.START, '').replace(PromptSequence.END, '')
+        return cmd
 
     def as_list(self):
         """Breaks up a command into a list.
@@ -85,13 +116,10 @@ class Macro:
         :return: The command as a list.
         """
         def prep(cmd):
-            if cmd:
-                cmd = shlex.split(cmd)
-            else:
-                cmd = []
-            return cmd
+            return shlex.split(cmd) if cmd else []
 
-        command = prep(self.prefix) + prep(self._command) + prep(self.suffix)
+        command = self._strip_prompt_from_command()
+        command = prep(self.prefix) + prep(command) + prep(self.suffix)
         return command
 
     def as_string(self):
@@ -100,7 +128,7 @@ class Macro:
         :rtype: str
         :return: The command as a string.
         """
-        cmd = self._command
+        cmd = self._strip_prompt_from_command()
         if self.prefix:
             cmd = self.prefix + ' ' + cmd
         if self.suffix:

--- a/build_magic/reference.py
+++ b/build_magic/reference.py
@@ -269,6 +269,15 @@ class OutputMethod(enum.Enum):
     PROCESS_SPINNER = 'process_spinner'
 
 
+@unique
+class PromptSequence(str, enum.Enum):
+    """Provides the prefix, suffix, and hidden strings that indicate a prompted variable."""
+
+    START = '<^^^^'
+    END = 'vvvv>'
+    HIDDEN = '******'
+
+
 class KeyTypes(EnumExt):
     """Valid public/private key types."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -733,7 +733,7 @@ def test_cli_prompt(cli, prompt_config):
     res = cli.invoke(build_magic, ['-C', prompt_config, '-v', 'user', 'elle', '--prompt', 'password'], input='secret\n')
     out = res.output
     assert res.exit_code == ExitCode.PASSED
-    assert 'EXECUTE : echo elle:secret' in out
+    assert 'EXECUTE : echo elle:******' in out
 
 
 def test_cli_variables_with_two_config_files(cli, variable_and_default_config):
@@ -759,16 +759,21 @@ def test_cli_variables_with_two_config_files(cli, variable_and_default_config):
 def test_cli_prompt_with_two_config_files(cli, prompt_and_default_config):
     """Verify using prompt still works when there is one config file with placeholders and one without."""
     # Without the default config
-    res = cli.invoke(build_magic, ['-C', 'prompt.yaml', '-v', 'user', 'elle', '--prompt', 'password'], input='secret\n')
+    res = cli.invoke(
+        build_magic,
+        ['-C', 'prompt.yaml', '-v', 'user', 'elle', '--prompt', 'password'],
+        input='secret\n',
+    )
     out = res.output
     assert res.exit_code == ExitCode.PASSED
-    assert 'EXECUTE : echo elle:secret' in out
+    assert 'EXECUTE : echo elle:******' in out
 
     # Including the default config
     res = cli.invoke(
         build_magic,
-        ['-C', 'prompt.yaml', '-C', 'build-magic.yaml', '-v', 'user', 'elle', '--prompt', 'password'], input='secret\n',
+        ['-C', 'prompt.yaml', '-C', 'build-magic.yaml', '-v', 'user', 'elle', '--prompt', 'password'],
+        input='secret\n',
     )
     out = res.output
     assert res.exit_code == ExitCode.PASSED
-    assert 'EXECUTE : echo elle:secret' in out
+    assert 'EXECUTE : echo elle:******' in out

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from build_magic.reference import PromptSequence
 from build_magic.macro import MacroFactory, Macro
 
 
@@ -28,6 +29,7 @@ def test_macro_create(cmd):
     macro = Macro(cmd)
     assert macro.sequence == 0
     assert macro._command == cmd
+    assert macro.command == cmd
     assert not macro.prefix
     assert not macro.suffix
     assert macro.as_string() == 'ls'
@@ -39,6 +41,7 @@ def test_macro_create_with_prefix(cmd, prefix):
     macro = Macro(cmd, prefix=prefix)
     assert macro.sequence == 0
     assert macro._command == 'ls'
+    assert macro.command == cmd
     assert macro.prefix == 'cd /tmp;'
     assert not macro.suffix
     assert macro.as_string() == 'cd /tmp; ls'
@@ -50,6 +53,7 @@ def test_macro_create_suffix(cmd, suffix):
     macro = Macro(cmd, suffix=suffix)
     assert macro.sequence == 0
     assert macro._command == 'ls'
+    assert macro.command == cmd
     assert not macro.prefix
     assert macro.suffix == '-ltr'
     assert macro.as_string() == 'ls -ltr'
@@ -61,6 +65,7 @@ def test_macro_create_prefix_suffix(cmd, prefix, suffix):
     macro = Macro(cmd, prefix=prefix, suffix=suffix)
     assert macro.sequence == 0
     assert macro._command == 'ls'
+    assert macro.command == cmd
     assert macro.prefix == 'cd /tmp;'
     assert macro.suffix == '-ltr'
     assert macro.as_string() == 'cd /tmp; ls -ltr'
@@ -97,6 +102,19 @@ def test_macro_add_suffix(cmd, suffix):
     assert macro.suffix == '-ltr'
     assert macro.as_string() == 'ls -ltr'
     assert macro.as_list() == ['ls', '-ltr']
+
+
+def test_macro_prompted_command():
+    """Verify prompted commands are handled correctly."""
+    cmd = f'echo {PromptSequence.START}secret{PromptSequence.END}'
+    macro = Macro(cmd)
+    assert macro.sequence == 0
+    assert macro._command == cmd
+    assert macro.command == f'echo {PromptSequence.HIDDEN}'
+    assert not macro.prefix
+    assert not macro.suffix
+    assert macro.as_string() == 'echo secret'
+    assert macro.as_list() == ['echo', 'secret']
 
 
 def test_macro_invalid_command():


### PR DESCRIPTION
* Modify prompted variables by adding prompt start and end tags to identify prompted text in a command.
* Modified the Macro command property to convert prompted text to hidden characters.
* Modified the Macro as_string and as_list methods to strip out prompted text tags before execution.
* Updated unit tests.

Closes #49 