### PR TITLE
docker_cleanup_permission_fix

### DIFF
--- a/build_magic/__init__.py
+++ b/build_magic/__init__.py
@@ -5,7 +5,7 @@
     * CommandRunner - An abstract class for defining methods for executing commands.
 """
 
-__version__ = '0.3.0rc2'
+__version__ = '0.3.0rc3'
 
 __all__ = [
     'cli',

--- a/build_magic/actions.py
+++ b/build_magic/actions.py
@@ -168,6 +168,8 @@ def _get_local_files_and_directories(files):
             file_hashes.append((str(file), hashlib.sha1(pathlib.Path(file).read_bytes()).hexdigest()))
         except IsADirectoryError:
             dirs.append(str(file))
+        except PermissionError:
+            continue
     return file_hashes, dirs
 
 

--- a/package/centos/build-magic/build-magic.spec
+++ b/package/centos/build-magic/build-magic.spec
@@ -1,5 +1,5 @@
 Name: build-magic
-Version: 0.3.0rc2
+Version: 0.3.0rc3
 Release: 0%{?dist}
 Summary: An un-opinionated build automation tool.
 BuildArch: x86_64

--- a/package/debian/build-magic/control
+++ b/package/debian/build-magic/control
@@ -1,5 +1,5 @@
 Package: build-magic
-Version: 0.3.0rc2
+Version: 0.3.0rc3
 Section: utils
 Priority: optional
 Architecture: amd64

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -345,17 +345,25 @@ def test_action_capture_dir_empty(empty_path, generic_runner, mocker):
 
 def test_action_capture_dir_error(build_path, generic_runner, mocker):
     """Test the case where capture_dir() raises an error."""
+    errors = (
+        IsADirectoryError,
+        PermissionError,
+        IsADirectoryError,
+        PermissionError,
+    )
     os.chdir(str(build_path))
     mocker.patch('build_magic.actions.container_up', return_value=True)
     # Local capture
-    mocker.patch('pathlib.Path.resolve', side_effect=IsADirectoryError)
+    mocker.patch('pathlib.Path.resolve', side_effect=errors)
     generic_runner.provision = types.MethodType(actions.capture_dir, generic_runner)
-    assert not generic_runner.provision()
+    assert not generic_runner.provision()  # IsADirectoryError
+    assert not generic_runner.provision()  # PermissionError
 
     # Docker capture
     generic_runner.host_wd = '.'
     generic_runner.provision = types.MethodType(actions.docker_capture_dir, generic_runner)
-    assert not generic_runner.provision()
+    assert not generic_runner.provision()  # IsADirectoryError
+    assert not generic_runner.provision()  # PermissionError
 
 
 def test_action_delete_new_files(build_hashes, build_path, generic_runner, mocker):

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -345,25 +345,36 @@ def test_action_capture_dir_empty(empty_path, generic_runner, mocker):
 
 def test_action_capture_dir_error(build_path, generic_runner, mocker):
     """Test the case where capture_dir() raises an error."""
-    errors = (
-        IsADirectoryError,
-        PermissionError,
-        IsADirectoryError,
-        PermissionError,
-    )
     os.chdir(str(build_path))
     mocker.patch('build_magic.actions.container_up', return_value=True)
     # Local capture
-    mocker.patch('pathlib.Path.resolve', side_effect=errors)
+    mocker.patch('pathlib.Path.resolve', side_effect=IsADirectoryError)
     generic_runner.provision = types.MethodType(actions.capture_dir, generic_runner)
-    assert not generic_runner.provision()  # IsADirectoryError
-    assert not generic_runner.provision()  # PermissionError
+    assert not generic_runner.provision()
 
     # Docker capture
     generic_runner.host_wd = '.'
     generic_runner.provision = types.MethodType(actions.docker_capture_dir, generic_runner)
-    assert not generic_runner.provision()  # IsADirectoryError
-    assert not generic_runner.provision()  # PermissionError
+    assert not generic_runner.provision()
+
+
+def test_action_capture_dir_permission_error(build_path, generic_runner, mocker):
+    """Test the case where a PermissionError is raised when trying to get the hash for a file."""
+    os.chdir(str(build_path))
+    mocker.patch('build_magic.actions.container_up', return_value=True)
+    mocker.patch('pathlib.Path.read_bytes', side_effect=PermissionError)
+    # Local capture
+    generic_runner.provision = types.MethodType(actions.capture_dir, generic_runner)
+    assert generic_runner.provision()
+    assert hasattr(generic_runner, '_existing_files')
+    assert len(generic_runner._existing_files) == 0
+
+    # Docker capture
+    generic_runner.host_wd = '.'
+    generic_runner.provision = types.MethodType(actions.capture_dir, generic_runner)
+    assert generic_runner.provision()
+    assert hasattr(generic_runner, '_existing_files')
+    assert len(generic_runner._existing_files) == 0
 
 
 def test_action_delete_new_files(build_hashes, build_path, generic_runner, mocker):


### PR DESCRIPTION
Added handling for permission errors when running the capture_dir function.

Closes #54 