### PR TITLE
docker_image_download_error

### DIFF
--- a/build_magic/actions.py
+++ b/build_magic/actions.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 
 import docker
-from docker.errors import APIError, DockerException, ImageLoadError
+from docker.errors import APIError, DockerException, ImageLoadError, ImageNotFound
 import vagrant
 
 from build_magic.exc import DockerDaemonError, VagrantNotFoundError
@@ -688,6 +688,8 @@ def container_up(self):
             mounts=[self.binding],
             name='build-magic',
         )
+    except ImageNotFound as err:
+        raise err
     except (APIError, AttributeError, ImageLoadError):
         return False
     return True

--- a/build_magic/core.py
+++ b/build_magic/core.py
@@ -450,6 +450,8 @@ class Stage:
                 _output.log(mode.PROCESS_SPINNER, spinner, process_active=False)
             raise SetupError(exception=err)
         if not result:
+            if spinner is not None:
+                _output.log(mode.PROCESS_SPINNER, spinner, process_active=False)
             raise SetupError
 
         # Call the command runner's prepare function.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Updated dependency versions.
 * Improved the error message when Docker or Vagrant isn't installed.
+* Fixed a bug that caused the spinner to continue running if the environment is a docker container that cannot be found.
+* Improved error handling in the case a docker container cannot be found.
 
 ## Version 0.3.0
 


### PR DESCRIPTION
* Added an exception handler to container_up() for the case where an image isn't found.
* Shut off the spinner if a provision function returns False.
* Updated unit tests.