### PR TITLE
vagrant_provisioner

### DIFF
--- a/build_magic/actions.py
+++ b/build_magic/actions.py
@@ -349,6 +349,9 @@ def vm_destroy(self):
     if hasattr(self, '_vm') and isinstance(self._vm, vagrant.Vagrant):
         try:
             self._vm.destroy()
+            # Remove the build-magic created Vagrantfile if it exists.
+            if pathlib.Path(self.environment).resolve().joinpath(self.alt_vagrantfile_name).exists():
+                pathlib.Path(self.environment).resolve().joinpath(self.alt_vagrantfile_name).unlink()
         except subprocess.CalledProcessError as err:
             print(str(err))
             return False

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ Added support for environment variables.
 Added support for command labels to optionally display instead of the command itself.
 Added support for job and stage descriptions.
 An environment can now be specified for the Local command runner and the stage will be skipped if the environment doesn't match the current OS or distribution.
+Build-magic creates and uses a custom Vagrantfile when using the Vagrant command runner and setting bind directory or envvars.
 
 ## Version 0.3.3 (Newest)
 


### PR DESCRIPTION
* Modified the vagrant command runner to create and use a custom Vagrantfile when setting the bind directory or environment variables.
* Added the vagrant command runner build_config() method.
* Added the vagrant command runner create_vagrantfile_config() method.
* Modified the vm_destroy() action to check for and delete the custom Vagrantfile if it exists.
* Updated unit tests.

Closes #76 